### PR TITLE
Add Docs for using another Databases

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 * [shiori](../README.md)
 * [Installation](installation.md)
+* [Databases](databases.md)
 * [Usage](usage.md)

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -4,17 +4,17 @@ To use another Database there are two options. You can use parameters while call
 
 ### Using command parameters
 
-| Parameter | Values | Description |
-|-----------|--------|---|
-| --db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
-| --db-dsn | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
-| --show-sql-log | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
+| Parameter | Default | Values | Description |
+|----------|--------|-------|---|
+| --db-type  | sqlite3 | sqlite3, mssql, mysql, postgres | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
+| --db-dsn | shiori.db | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
+| --show-sql-log | false | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
 
 ### Using environment Variables
 
-| Variable | Values | Description |
-|-----------|--------|---|
-| SHIORI_DBTYPE   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
-| SHIORI_DSN | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
-| SHIORI_SHOW_SQL | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
+| Variable | Default | Values | Description |
+|----------|--------|-------|---|
+| SHIORI_DBTYPE | sqlite3  | sqlite3, mssql, mysql, postgres | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
+| SHIORI_DSN | shiori.db | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
+| SHIORI_SHOW_SQL | false | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
 

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -6,7 +6,7 @@ To use another Database there are two options. You can use parameters while call
 
 | Parameter | Values | Description |
 |-----------|--------|---|
-| --db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm dos for more informations |
+| --db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
 | --db-dsn | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
 | --show-sql-log | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
 
@@ -14,7 +14,7 @@ To use another Database there are two options. You can use parameters while call
 
 | Variable | Values | Description |
 |-----------|--------|---|
-| SHIORI_DBTYPE   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm dos for more informations |
+| SHIORI_DBTYPE   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm docs for more informations |
 | SHIORI_DSN | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
 | SHIORI_SHOW_SQL | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
 

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -4,6 +4,17 @@ To use another Database there are two options. You can use parameters while call
 
 ### Using command parameters
 
-| Parameter | Values |
-|-----------|--------|
-| db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle |
+| Parameter | Values | Description |
+|-----------|--------|---|
+| --db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm dos for more informations |
+| --db-dsn | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
+| --show-sql-log | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
+
+### Using environment Variables
+
+| Variable | Values | Description |
+|-----------|--------|---|
+| SHIORI_DBTYPE   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle | since this Shiori fork uses xorm as database layer, you can use several Databases. Check out the xorm dos for more informations |
+| SHIORI_DSN | user:password@(localhost)/dbname?charset=utf8&parseTime=True&loc=Local | Your Database Connection string |
+| SHIORI_SHOW_SQL | - | Bool, if set, Shiori will output all SQL Queries to the CLI |
+

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -1,0 +1,9 @@
+## Using other Databases
+
+To use another Database there are two options. You can use parameters while calling the shiori command itself or you can set environment variables.
+
+### Using command parameters
+
+| Parameter | Values |
+|-----------|--------|
+| db-type   | mssql, odbc, mysql, mymysql, postgres, pgx, sqlite3, oci8, goracle |


### PR DESCRIPTION
Hey there, as said in Issue #9 I've started adding Docs for using another Database Engines.

Could you validate my findings?

I used following file as base for my docs:

https://github.com/techknowlogick/shiori/blob/master/main.go#L38

If it is okay for you, i would add a link to the main Readme and beautify this up.