### PR TITLE
Dockerfile: copy dist to final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV ENV_SHIORI_DIR /srv/shiori/
 
 RUN apk --no-cache add dumb-init ca-certificates
 COPY --from=gobuilder /go/src/src.techknowlogick.com/shiori/shiori /usr/local/bin/shiori
+COPY --from=gobuilder /go/src/src.techknowlogick.com/shiori/dist /dist
 
 WORKDIR /srv/
 RUN mkdir shiori


### PR DESCRIPTION
`shiori serve` in container expects the web UI files to be present in `/dist`. This PR ensures its copied to the final container

Fixes #310 