### PR TITLE
cmd/serve/root: use correct flag for server-debug

### DIFF
--- a/cmd/serve/root.go
+++ b/cmd/serve/root.go
@@ -80,7 +80,7 @@ var (
 			port := c.Int("port")
 
 			// Create router
-			if !c.Bool("debug") {
+			if !c.Bool("server-debug") {
 				gin.SetMode(gin.ReleaseMode)
 			}
 


### PR DESCRIPTION
Flag was renamed from `debug` to `server-debug`