### PR TITLE
cmd/serve/web-handler-ui: marshal to json in serveBookmarkCache

### DIFF
--- a/cmd/serve/web-handler-ui.go
+++ b/cmd/serve/web-handler-ui.go
@@ -117,7 +117,10 @@ func (h *webHandler) serveBookmarkCache(c *gin.Context) {
 	tplCache, err := createTemplate("cache.html", funcMap)
 	utils.CheckError(err)
 
-	err = tplCache.Execute(c.Writer, &bookmarks[0])
+	bt, err := json.Marshal(bookmarks[0])
+	utils.CheckError(err)
+
+	err = tplCache.Execute(c.Writer, string(bt))
 	utils.CheckError(err)
 }
 


### PR DESCRIPTION
`tplCache.Execute` would render the bookmark object as a string, it should be converted to json first